### PR TITLE
Revert "begone git lfs"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,3 +16,13 @@
 /.gitbook.yaml      export-ignore
 .images/            export-ignore
 docs/               export-ignore
+
+*.png filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.wav filter=lfs diff=lfs merge=lfs -text
+*.ogg filter=lfs diff=lfs merge=lfs -text
+*.scn filter=lfs diff=lfs merge=lfs -text
+*.res filter=lfs diff=lfs merge=lfs -text
+*.ttf filter=lfs diff=lfs merge=lfs -text
+*.gif filter=lfs diff=lfs merge=lfs -text
+*.svg filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Reverts AnidemDex/Godot-CommandTimeline#2

LFS is necessary. SVG and text related files should be removed from LFS instead