### PR TITLE
Play/stop icons for "Continue at end" option

### DIFF
--- a/editor/timeline_displayer.gd
+++ b/editor/timeline_displayer.gd
@@ -100,9 +100,11 @@ func _build_item(item:TreeItem, command:Command) -> void:
 		item.erase_button(last_column, ButtonHint.CONTINUE_AT_END)
 	
 	hint = "CommandManager will stop when this command ends."
+	var continue_icon = get_theme_icon("Stop", "EditorIcons")
 	if command.continue_at_end:
 		hint = "CommandManager will continue automatically to next command when this command ends."
-	item.add_button(last_column, get_theme_icon("Stop", "EditorIcons"), ButtonHint.CONTINUE_AT_END, command.continue_at_end, hint)
+		continue_icon = get_theme_icon("Play", "EditorIcons")
+	item.add_button(last_column, continue_icon, ButtonHint.CONTINUE_AT_END, false, hint)
 
 
 func _gui_input(event: InputEvent) -> void:

--- a/icons/Timer.svg.import
+++ b/icons/Timer.svg.import
@@ -6,7 +6,7 @@ uid="uid://xfppf2h5gjv5"
 path="res://.godot/imported/Timer.svg-9794fbdf79472eadc62aaac8fe455e2e.ctex"
 metadata={
 "editor_dark_theme": true,
-"editor_scale": 0.75,
+"editor_scale": 1.0,
 "has_editor_variant": true,
 "vram_texture": false
 }

--- a/icons/animation.svg.import
+++ b/icons/animation.svg.import
@@ -6,7 +6,7 @@ uid="uid://b3nr8vwoeq6co"
 path="res://.godot/imported/animation.svg-96bb5333edd4909624777a9c9d4a7760.ctex"
 metadata={
 "editor_dark_theme": true,
-"editor_scale": 0.75,
+"editor_scale": 1.0,
 "has_editor_variant": true,
 "vram_texture": false
 }

--- a/icons/bookmark.svg.import
+++ b/icons/bookmark.svg.import
@@ -6,7 +6,7 @@ uid="uid://be5o16d16ugdv"
 path="res://.godot/imported/bookmark.svg-82508ea2542c0fb3695c2c61eba9090b.ctex"
 metadata={
 "editor_dark_theme": true,
-"editor_scale": 0.75,
+"editor_scale": 1.0,
 "has_editor_variant": true,
 "vram_texture": false
 }

--- a/icons/branch.svg.import
+++ b/icons/branch.svg.import
@@ -6,7 +6,7 @@ uid="uid://bmpioqcojkwso"
 path="res://.godot/imported/branch.svg-90616a165dd595bdb39d1551185f36d2.ctex"
 metadata={
 "editor_dark_theme": true,
-"editor_scale": 0.75,
+"editor_scale": 1.0,
 "has_editor_variant": true,
 "vram_texture": false
 }

--- a/icons/character.svg.import
+++ b/icons/character.svg.import
@@ -6,7 +6,7 @@ uid="uid://c6fay6yi7ee4h"
 path="res://.godot/imported/character.svg-dfa800b6c538c4cc63d29c9fc5a022fd.ctex"
 metadata={
 "editor_dark_theme": true,
-"editor_scale": 0.75,
+"editor_scale": 1.0,
 "has_editor_variant": true,
 "vram_texture": false
 }

--- a/icons/comment.svg.import
+++ b/icons/comment.svg.import
@@ -6,7 +6,7 @@ uid="uid://bqwcah64uhsse"
 path="res://.godot/imported/comment.svg-23337e76f1842091fe042d8624d84723.ctex"
 metadata={
 "editor_dark_theme": true,
-"editor_scale": 0.75,
+"editor_scale": 1.0,
 "has_editor_variant": true,
 "vram_texture": false
 }

--- a/icons/function.svg.import
+++ b/icons/function.svg.import
@@ -6,7 +6,7 @@ uid="uid://beu8kl5rwy8nj"
 path="res://.godot/imported/function.svg-fb4ed8bdf43831b69d675649eea671c8.ctex"
 metadata={
 "editor_dark_theme": true,
-"editor_scale": 0.75,
+"editor_scale": 1.0,
 "has_editor_variant": true,
 "vram_texture": false
 }

--- a/icons/jump.svg.import
+++ b/icons/jump.svg.import
@@ -6,7 +6,7 @@ uid="uid://bwgcct8iprhk0"
 path="res://.godot/imported/jump.svg-1b129eae2ba449be5d220e32ee0d8ebc.ctex"
 metadata={
 "editor_dark_theme": true,
-"editor_scale": 0.75,
+"editor_scale": 1.0,
 "has_editor_variant": true,
 "vram_texture": false
 }

--- a/icons/picture.svg.import
+++ b/icons/picture.svg.import
@@ -6,7 +6,7 @@ uid="uid://c4txcaxf1sinr"
 path="res://.godot/imported/picture.svg-a49798352b09bf6be7d857c6d1669d55.ctex"
 metadata={
 "editor_dark_theme": true,
-"editor_scale": 0.75,
+"editor_scale": 1.0,
 "has_editor_variant": true,
 "vram_texture": false
 }

--- a/icons/play.svg.import
+++ b/icons/play.svg.import
@@ -6,7 +6,7 @@ uid="uid://bvccooreyje12"
 path="res://.godot/imported/play.svg-f6c1778f26a9cb162d89fb8c1abe906b.ctex"
 metadata={
 "editor_dark_theme": true,
-"editor_scale": 0.75,
+"editor_scale": 1.0,
 "has_editor_variant": true,
 "vram_texture": false
 }

--- a/icons/return.svg.import
+++ b/icons/return.svg.import
@@ -6,7 +6,7 @@ uid="uid://b0wdol0ji4a0v"
 path="res://.godot/imported/return.svg-3c0faf52579095e2a13ee6b9914f7c5b.ctex"
 metadata={
 "editor_dark_theme": true,
-"editor_scale": 0.75,
+"editor_scale": 1.0,
 "has_editor_variant": true,
 "vram_texture": false
 }

--- a/icons/settings.svg.import
+++ b/icons/settings.svg.import
@@ -6,7 +6,7 @@ uid="uid://dmw3tcetgc6kt"
 path="res://.godot/imported/settings.svg-7bb415dae634a28b0a8938b9be4570bc.ctex"
 metadata={
 "editor_dark_theme": true,
-"editor_scale": 0.75,
+"editor_scale": 1.0,
 "has_editor_variant": true,
 "vram_texture": false
 }

--- a/icons/sliders.svg.import
+++ b/icons/sliders.svg.import
@@ -6,7 +6,7 @@ uid="uid://8nc2r5ttrk7g"
 path="res://.godot/imported/sliders.svg-bdaac90bb94d8f07d99af1feb5d3af57.ctex"
 metadata={
 "editor_dark_theme": true,
-"editor_scale": 0.75,
+"editor_scale": 1.0,
 "has_editor_variant": true,
 "vram_texture": false
 }

--- a/icons/speech.svg.import
+++ b/icons/speech.svg.import
@@ -6,7 +6,7 @@ uid="uid://c7y7eq1lww26h"
 path="res://.godot/imported/speech.svg-ec635dcdc5317e3c596a6c0735cd4fc2.ctex"
 metadata={
 "editor_dark_theme": true,
-"editor_scale": 0.75,
+"editor_scale": 1.0,
 "has_editor_variant": true,
 "vram_texture": false
 }

--- a/icons/timeline.svg.import
+++ b/icons/timeline.svg.import
@@ -6,7 +6,7 @@ uid="uid://cw3xkh4kv8ng"
 path="res://.godot/imported/timeline.svg-6779e58c1b1d9770a2c8d7452b569f3f.ctex"
 metadata={
 "editor_dark_theme": true,
-"editor_scale": 0.75,
+"editor_scale": 1.0,
 "has_editor_variant": true,
 "vram_texture": false
 }


### PR DESCRIPTION
Swapping the icons instead means it'll no longer be in "disabled" state aka both states will be clickable for the future swapping
Godot changed editor scale for all icons to 1.0 so I guess I'll do that as well