### PR TITLE
Make the STOP icon red and more saturated to stand out

### DIFF
--- a/commands/command_wait.gd
+++ b/commands/command_wait.gd
@@ -27,4 +27,4 @@ func _get_hint() -> String:
 
 
 func _get_icon() -> Texture:
-	return load("res://addons/blockflow/icons/Timer.svg")
+	return load("res://addons/blockflow/icons/timer.svg")

--- a/editor/timeline_displayer.gd
+++ b/editor/timeline_displayer.gd
@@ -4,8 +4,8 @@ extends Tree
 const TimelineClass = preload("res://addons/blockflow/timeline.gd")
 const FALLBACK_ICON = preload("res://icon.svg")
 const BOOKMARK_ICON = preload("res://addons/blockflow/icons/bookmark.svg")
-const STOP_ICON = preload("res://addons/blockflow/icons/Stop.svg")
-const CONTINUE_ICON = preload("res://addons/blockflow/icons/Play.svg")
+const STOP_ICON = preload("res://addons/blockflow/icons/stop.svg")
+const CONTINUE_ICON = preload("res://addons/blockflow/icons/play.svg")
 enum ButtonHint {CONTINUE_AT_END}
 
 

--- a/editor/timeline_displayer.gd
+++ b/editor/timeline_displayer.gd
@@ -3,6 +3,9 @@ extends Tree
 
 const TimelineClass = preload("res://addons/blockflow/timeline.gd")
 const FALLBACK_ICON = preload("res://icon.svg")
+const BOOKMARK_ICON = preload("res://addons/blockflow/icons/bookmark.svg")
+const STOP_ICON = preload("res://addons/blockflow/icons/Stop.svg")
+const CONTINUE_ICON = preload("res://addons/blockflow/icons/Play.svg")
 enum ButtonHint {CONTINUE_AT_END}
 
 
@@ -76,7 +79,7 @@ func _build_item(item:TreeItem, command:Command) -> void:
 	
 	if not command.label.is_empty():
 		hint += "Label:\n"+command.label
-		bookmark = load("res://addons/blockflow/icons/bookmark.svg")
+		bookmark = BOOKMARK_ICON
 	
 	for i in columns:
 		item.set_icon_max_width(i, 32)
@@ -100,10 +103,10 @@ func _build_item(item:TreeItem, command:Command) -> void:
 		item.erase_button(last_column, ButtonHint.CONTINUE_AT_END)
 	
 	hint = "CommandManager will stop when this command ends."
-	var continue_icon = get_theme_icon("Stop", "EditorIcons")
+	var continue_icon = STOP_ICON
 	if command.continue_at_end:
 		hint = "CommandManager will continue automatically to next command when this command ends."
-		continue_icon = get_theme_icon("Play", "EditorIcons")
+		continue_icon = CONTINUE_ICON
 	item.add_button(last_column, continue_icon, ButtonHint.CONTINUE_AT_END, false, hint)
 
 

--- a/icons/Stop.svg
+++ b/icons/Stop.svg
@@ -1,0 +1,1 @@
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m4 1048.4v-8h8v8z" fill="#D95B43" fill-rule="evenodd" stroke="#D95B43" stroke-linejoin="round" stroke-width="2" transform="translate(0 -1036.4)"/></svg>

--- a/icons/Stop.svg
+++ b/icons/Stop.svg
@@ -1,1 +1,1 @@
-<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m4 1048.4v-8h8v8z" fill="#D95B43" fill-rule="evenodd" stroke="#D95B43" stroke-linejoin="round" stroke-width="2" transform="translate(0 -1036.4)"/></svg>
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m4 1048.4v-8h8v8z" fill="#ff4545" fill-rule="evenodd" stroke="#ff4545" stroke-linejoin="round" stroke-width="2" transform="translate(0 -1036.4)"/></svg>

--- a/icons/Stop.svg.import
+++ b/icons/Stop.svg.import
@@ -3,7 +3,7 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://7ox5n3pwcths"
-path="res://.godot/imported/Stop.svg-a7ab617b96c8066f1d15ffb691436cf5.ctex"
+path="res://.godot/imported/stop.svg-a7ab617b96c8066f1d15ffb691436cf5.ctex"
 metadata={
 "editor_dark_theme": true,
 "editor_scale": 1.0,
@@ -13,8 +13,8 @@ metadata={
 
 [deps]
 
-source_file="res://addons/blockflow/icons/Stop.svg"
-dest_files=["res://.godot/imported/Stop.svg-a7ab617b96c8066f1d15ffb691436cf5.ctex"]
+source_file="res://addons/blockflow/icons/stop.svg"
+dest_files=["res://.godot/imported/stop.svg-a7ab617b96c8066f1d15ffb691436cf5.ctex"]
 
 [params]
 

--- a/icons/Stop.svg.import
+++ b/icons/Stop.svg.import
@@ -5,6 +5,9 @@ type="CompressedTexture2D"
 uid="uid://7ox5n3pwcths"
 path="res://.godot/imported/Stop.svg-a7ab617b96c8066f1d15ffb691436cf5.ctex"
 metadata={
+"editor_dark_theme": true,
+"editor_scale": 1.0,
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +36,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/icons/Stop.svg.import
+++ b/icons/Stop.svg.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://c1df7v3gra7q1"
-path="res://.godot/imported/Play.svg-d8ea6b946ce36a5fa1a5c95795c75e73.ctex"
+uid="uid://7ox5n3pwcths"
+path="res://.godot/imported/Stop.svg-a7ab617b96c8066f1d15ffb691436cf5.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://addons/blockflow/icons/Play.svg"
-dest_files=["res://.godot/imported/Play.svg-d8ea6b946ce36a5fa1a5c95795c75e73.ctex"]
+source_file="res://addons/blockflow/icons/Stop.svg"
+dest_files=["res://.godot/imported/Stop.svg-a7ab617b96c8066f1d15ffb691436cf5.ctex"]
 
 [params]
 

--- a/icons/Timer.svg.import
+++ b/icons/Timer.svg.import
@@ -3,7 +3,7 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://xfppf2h5gjv5"
-path="res://.godot/imported/Timer.svg-9794fbdf79472eadc62aaac8fe455e2e.ctex"
+path="res://.godot/imported/timer.svg-9794fbdf79472eadc62aaac8fe455e2e.ctex"
 metadata={
 "editor_dark_theme": true,
 "editor_scale": 1.0,
@@ -13,8 +13,8 @@ metadata={
 
 [deps]
 
-source_file="res://addons/blockflow/icons/Timer.svg"
-dest_files=["res://.godot/imported/Timer.svg-9794fbdf79472eadc62aaac8fe455e2e.ctex"]
+source_file="res://addons/blockflow/icons/timer.svg"
+dest_files=["res://.godot/imported/timer.svg-9794fbdf79472eadc62aaac8fe455e2e.ctex"]
 
 [params]
 

--- a/icons/play.svg
+++ b/icons/play.svg
@@ -1,11 +1,1 @@
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
-<svg width="100px" height="100px" viewBox="-0.5 0 8 8" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" fill="#E0E0E0">
-
-<g id="SVGRepo_bgCarrier" stroke-width="0"/>
-
-<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
-
-<g id="SVGRepo_iconCarrier"> <title>play [#C0C0C0]</title> <desc>Created with Sketch.</desc> <defs> </defs> <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"> <g id="Dribbble-Light-Preview" transform="translate(-427.000000, -3765.000000)" fill="#E0E0E0"> <g id="icons" transform="translate(56.000000, 160.000000)"> <polygon id="play-[#C0C0C0]" points="371 3605 371 3613 378 3609"> </polygon> </g> </g> </g> </g>
-
-</svg>
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m4.9883 1039.4c-.5469.01-.98717.4511-.98828.998v8c.0001163.7986.89011 1.275 1.5547.8321l6-4c.59362-.3959.59362-1.2682 0-1.6641l-6-4c-.1678-.1111-.3652-.1689-.56641-.166z" fill="#e0e0e0" fill-rule="evenodd" transform="translate(0 -1036.4)"/></svg>

--- a/icons/play.svg.import
+++ b/icons/play.svg.import
@@ -5,6 +5,9 @@ type="CompressedTexture2D"
 uid="uid://c1df7v3gra7q1"
 path="res://.godot/imported/Play.svg-d8ea6b946ce36a5fa1a5c95795c75e73.ctex"
 metadata={
+"editor_dark_theme": true,
+"editor_scale": 1.0,
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +36,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/icons/play.svg.import
+++ b/icons/play.svg.import
@@ -3,7 +3,7 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://c1df7v3gra7q1"
-path="res://.godot/imported/Play.svg-d8ea6b946ce36a5fa1a5c95795c75e73.ctex"
+path="res://.godot/imported/play.svg-d8ea6b946ce36a5fa1a5c95795c75e73.ctex"
 metadata={
 "editor_dark_theme": true,
 "editor_scale": 1.0,
@@ -13,8 +13,8 @@ metadata={
 
 [deps]
 
-source_file="res://addons/blockflow/icons/Play.svg"
-dest_files=["res://.godot/imported/Play.svg-d8ea6b946ce36a5fa1a5c95795c75e73.ctex"]
+source_file="res://addons/blockflow/icons/play.svg"
+dest_files=["res://.godot/imported/play.svg-d8ea6b946ce36a5fa1a5c95795c75e73.ctex"]
 
 [params]
 


### PR DESCRIPTION
change icon loading from load() to preload() consts
![image](https://github.com/AnidemDex/Godot-CommandTimeline/assets/3470436/2476fdc3-1ffd-450b-8f8a-56cca1c0c40f)

Closes https://github.com/AnidemDex/Godot-CommandTimeline/issues/33 