### PR TITLE
Fix animate and goto commands

### DIFF
--- a/commands/command_animate.gd
+++ b/commands/command_animate.gd
@@ -22,7 +22,7 @@ func _execution_steps() -> void:
 	
 	if wait_until_animation_ends:
 		animation_player.animation_finished.connect(
-			Callable(self, "emit_signal").bind("command_finished"),
+			animation_ends,
 			CONNECT_ONE_SHOT
 			)
 	
@@ -34,6 +34,8 @@ func _execution_steps() -> void:
 	if not wait_until_animation_ends:
 		command_finished.emit()
 
+func animation_ends(_anim: String):
+	command_finished.emit()
 
 func _get_name() -> String:
 	return "Animate"

--- a/commands/command_goto.gd
+++ b/commands/command_goto.gd
@@ -93,7 +93,9 @@ func _fake_process() -> void:
 	if _condition_is_true():
 		_go_to_defined_command()
 	else:
-		(Engine.get_main_loop() as SceneTree).process_frame.connect(_fake_process, CONNECT_ONE_SHOT)
+		var main_loop = Engine.get_main_loop() as SceneTree
+		if not main_loop.process_frame.is_connected(_fake_process):
+			main_loop.process_frame.connect(_fake_process, CONNECT_ONE_SHOT)
 
 
 func _get_name() -> String:


### PR DESCRIPTION
Fix animate command callable being given the "animation" name, even though we're okay with discarding it

Fix goto command trying to connect process_frame to _fake_process more than once