### PR TITLE
Add a hint string for animate command, add access to custom_speed and custom_blend

### DIFF
--- a/commands/command_animate.gd
+++ b/commands/command_animate.gd
@@ -1,9 +1,25 @@
 @tool
 extends Command
 
-@export var animation:String = ""
-@export var play_backwards:bool = false
-@export var wait_until_animation_ends:bool = false
+@export var animation:String = "":
+	set(value):
+		animation = value
+		emit_changed()
+	get:
+		return animation
+@export var play_backwards:bool = false:
+	set(value):
+		play_backwards = value
+		emit_changed()
+	get:
+		return play_backwards
+@export var wait_until_animation_ends:bool = false:
+	set(value):
+		wait_until_animation_ends = value
+		emit_changed()
+	get:
+		return wait_until_animation_ends
+
 
 func _execution_steps() -> void:
 	command_started.emit()
@@ -41,3 +57,14 @@ func _get_name() -> String:
 
 func _get_icon() -> Texture:
 	return load("res://addons/blockflow/icons/animation.svg")
+
+
+func _get_hint() -> String:
+	var hint_str = "play '" + animation + "'"
+	if play_backwards:
+		hint_str += " backwards"
+	if wait_until_animation_ends:
+		hint_str += " and wait"
+	if target != NodePath():
+		hint_str += " on " + str(target)
+	return hint_str

--- a/commands/command_animate.gd
+++ b/commands/command_animate.gd
@@ -13,7 +13,7 @@ extends Command
 		emit_changed()
 	get:
 		return custom_blend
-@export_range(0.0001, 1000.0) var custom_speed:float = 1.0:
+@export_range(0.001, 100.0) var custom_speed:float = 1.0:
 	set(value):
 		custom_speed = value
 		emit_changed()
@@ -25,12 +25,12 @@ extends Command
 		emit_changed()
 	get:
 		return play_backwards
-@export var wait_until_animation_ends:bool = false:
+@export var wait_until_finished:bool = false:
 	set(value):
-		wait_until_animation_ends = value
+		wait_until_finished = value
 		emit_changed()
 	get:
-		return wait_until_animation_ends
+		return wait_until_finished
 
 
 func _execution_steps() -> void:
@@ -48,7 +48,7 @@ func _execution_steps() -> void:
 		command_finished.emit()
 		return
 	
-	if wait_until_animation_ends:
+	if wait_until_finished:
 		animation_player.animation_finished.connect(
 			Callable(self, "emit_signal").bind("command_finished"),
 			CONNECT_ONE_SHOT
@@ -60,7 +60,7 @@ func _execution_steps() -> void:
 		play_backwards
 		)
 	
-	if not wait_until_animation_ends:
+	if not wait_until_finished:
 		command_finished.emit()
 
 
@@ -74,10 +74,14 @@ func _get_icon() -> Texture:
 
 func _get_hint() -> String:
 	var hint_str = "play '" + animation + "'"
+	if custom_blend != -1:
+		hint_str += " with blend of " + str(custom_blend)
+	if custom_speed != 1.0:
+		hint_str += " at speed " + str(custom_speed)
 	if play_backwards:
 		hint_str += " backwards"
-	if wait_until_animation_ends:
-		hint_str += " and wait"
+	if wait_until_finished:
+		hint_str += " and wait until finished"
 	if target != NodePath():
 		hint_str += " on " + str(target)
 	return hint_str

--- a/commands/command_animate.gd
+++ b/commands/command_animate.gd
@@ -7,6 +7,18 @@ extends Command
 		emit_changed()
 	get:
 		return animation
+@export_range(-1, 1) var custom_blend:float = -1:
+	set(value):
+		custom_blend = value
+		emit_changed()
+	get:
+		return custom_blend
+@export_range(0.0001, 1000.0) var custom_speed:float = 1.0:
+	set(value):
+		custom_speed = value
+		emit_changed()
+	get:
+		return custom_speed
 @export var play_backwards:bool = false:
 	set(value):
 		play_backwards = value
@@ -41,11 +53,12 @@ func _execution_steps() -> void:
 			Callable(self, "emit_signal").bind("command_finished"),
 			CONNECT_ONE_SHOT
 			)
-	
-	if play_backwards:
-		(target_node as AnimationPlayer).play_backwards(animation)
-	else:
-		(target_node as AnimationPlayer).play(animation)
+
+	(target_node as AnimationPlayer).play(animation,
+		custom_blend,
+		(-custom_speed if play_backwards else custom_speed),
+		play_backwards
+		)
 	
 	if not wait_until_animation_ends:
 		command_finished.emit()


### PR DESCRIPTION
Add a hint string for animate command:
![image](https://github.com/AnidemDex/Godot-CommandTimeline/assets/3470436/980a45b3-d10e-4ecd-9a1a-a41bb77a5911)

Expand on animate command to give access to custom_blend and custom_speed variables
rename "wait_until_animation_ends" to "wait_until_finished"