### PR TITLE
Fix 39 updating `Return` command

### DIFF
--- a/command_manager.gd
+++ b/command_manager.gd
@@ -92,6 +92,7 @@ func go_to_command(command_idx:int, timeline:Timeline=null) -> void:
 		_notify_timeline_end()
 		return
 	
+	_execute_command(current_command)
 	# Add to history
 	# TODO: Consider moving to its own function.
 	_history.append([current_timeline, current_command_idx])
@@ -107,7 +108,6 @@ func go_to_command(command_idx:int, timeline:Timeline=null) -> void:
 					"index":current_command.get_target_command_index()
 				}
 			])
-	_execute_command(current_command)
 
 ## Advances to the next command in the current timeline.
 func go_to_next_command() -> void:

--- a/command_manager.gd
+++ b/command_manager.gd
@@ -120,8 +120,8 @@ func go_to_previous_command() -> void:
 	assert(false)
 	pass
 
-
-func _execute_command(command:Command) -> void:
+# Set required data for a command. Used before _execute_command
+func _prepare_command(command:Command) -> void:
 	if command == null:
 		assert(false)
 		return
@@ -141,6 +141,12 @@ func _execute_command(command:Command) -> void:
 	if not is_instance_valid(target_node):
 		target_node = self
 	command.target_node = target_node
+
+
+func _execute_command(command:Command) -> void:
+	if command == null:
+		assert(false)
+		return
 	
 	command.execution_steps.call()
 

--- a/commands/command.gd
+++ b/commands/command.gd
@@ -108,8 +108,8 @@ func _execution_steps() -> void:
 ## The command name is also used when editor is creating command buttons in
 ## editor.
 func _get_name() -> String:
-	assert(false, "_get_name()")
-	return "UNKNOW_COMMAND"
+	assert(!resource_name.is_empty(), "_get_name()")
+	return "UNKNOW_COMMAND" if resource_name.is_empty() else resource_name
 
 
 ## Returns this command icon.

--- a/commands/command_goto.gd
+++ b/commands/command_goto.gd
@@ -38,19 +38,21 @@ var condition:String:
 ## Helper function to get the defined [timeline]
 func get_target_timeline() -> Timeline:
 	var target_timeline:Timeline = timeline
-	var current_timeline:Timeline = command_manager.timeline
+	var current_timeline:Timeline = command_manager.current_timeline
+	if not target_timeline:
+		target_timeline = current_timeline
 	
-	return null
+	return target_timeline
 
 ## Helper function to get the defined command index according to [command_index]
 ## and [command_bookmark]
-func get_target_command_index() -> Command:
+func get_target_command_index() -> int:
 	var target_timeline = get_target_timeline()
 	var target_command = command_index
 	if use_bookmark:
 		target_command = target_timeline.get_command_by_bookmark(command_bookmark)
 		command_index = target_timeline.get_command_idx(target_command)
-	return null
+	return target_command
 
 
 func _execution_steps() -> void:
@@ -89,7 +91,7 @@ func _condition_is_true() -> bool:
 
 func _go_to_defined_command() -> void:
 	var target_timeline:Timeline = get_target_timeline()
-	var target_command:Command = get_target_command_index()
+	var target_command:int = get_target_command_index()
 	
 	command_manager.go_to_command(target_command, target_timeline)
 

--- a/commands/command_goto.gd
+++ b/commands/command_goto.gd
@@ -35,6 +35,23 @@ var condition:String:
 	get:
 		return condition
 
+## Helper function to get the defined [timeline]
+func get_target_timeline() -> Timeline:
+	var target_timeline:Timeline = timeline
+	var current_timeline:Timeline = command_manager.timeline
+	
+	return null
+
+## Helper function to get the defined command index according to [command_index]
+## and [command_bookmark]
+func get_target_command_index() -> Command:
+	var target_timeline = get_target_timeline()
+	var target_command = command_index
+	if use_bookmark:
+		target_command = target_timeline.get_command_by_bookmark(command_bookmark)
+		command_index = target_timeline.get_command_idx(target_command)
+	return null
+
 
 func _execution_steps() -> void:
 	command_started.emit()
@@ -45,6 +62,7 @@ func _execution_steps() -> void:
 		_go_to_defined_command()
 		return
 	
+	# unless it fails and the condition is not true.
 	command_finished.emit()
 
 
@@ -70,22 +88,10 @@ func _condition_is_true() -> bool:
 
 
 func _go_to_defined_command() -> void:
-	var target_timeline:Timeline = command_manager.timeline
+	var target_timeline:Timeline = get_target_timeline()
+	var target_command:Command = get_target_command_index()
 	
-	if timeline:
-		target_timeline = timeline
-	
-	if use_bookmark:
-		var target_command = target_timeline.get_command_by_bookmark(command_bookmark)
-		command_index = target_timeline.get_command_idx(target_command)
-	
-	if timeline:
-		# Now looking at it, this seems wrong.
-		command_manager.timeline = timeline
-		command_manager.start_timeline(command_index)
-		return
-	
-	command_manager.go_to_command(command_index)
+	command_manager.go_to_command(target_command, target_timeline)
 
 
 func _get_name() -> String:

--- a/commands/command_return.gd
+++ b/commands/command_return.gd
@@ -1,9 +1,13 @@
 @tool
 extends Command
 
+enum ReturnValue {BEFORE=-1,NO_RETURN, AFTER}
+
+var returns_to:int = ReturnValue.AFTER
+
 func _execution_steps() -> void:
 	command_started.emit()
-	pass
+	command_manager.return_command(returns_to)
 
 
 func _get_name() -> String:

--- a/commands/command_return.gd
+++ b/commands/command_return.gd
@@ -2,6 +2,7 @@
 extends Command
 
 func _execution_steps() -> void:
+	command_started.emit()
 	pass
 
 

--- a/timeline.gd
+++ b/timeline.gd
@@ -16,8 +16,7 @@ var commands:Array[Command]:
 		return commands
 
 var _bookmarks:Dictionary
-# timeline
-var _history_queue:Array
+
 
 ## Adds a [Command] to the timeline
 func add_command(command:Command) -> void:

--- a/timeline.gd
+++ b/timeline.gd
@@ -1,7 +1,6 @@
 @tool
 extends Resource
 class_name Timeline
-
 ##
 ## Base class for all Timelines
 ##
@@ -17,6 +16,8 @@ var commands:Array[Command]:
 		return commands
 
 var _bookmarks:Dictionary
+# timeline
+var _history_queue:Array
 
 ## Adds a [Command] to the timeline
 func add_command(command:Command) -> void:


### PR DESCRIPTION
PR fixes #39 updating `Return` command.

It makes heavy changes on `CommandManager` adding new methods to manipulate `go_to_command` or to `return_command`.

It also adds a pseudo history through `CommandManager._history` and `CommandManager._jump_history`, used by those two mentioned functions.